### PR TITLE
* Made Extensions.Shuffle() more random if called in close succession.

### DIFF
--- a/UnityGameBase/Core/Utils/Extensions.cs
+++ b/UnityGameBase/Core/Utils/Extensions.cs
@@ -89,7 +89,12 @@ namespace UnityGameBase.Core.Extensions
         
         public static void Shuffle<T>(this List<T> list)
         {
-            System.Random rng = new System.Random();  
+            // System.Random() initialisation is obviously based on a low
+            // resolution timestamp of the current time, which yields
+            // identical shuffles if called in close succession.
+            // Solution: Use milliseconds, which provide more variation.
+            System.Random rng = new System.Random(System.DateTime.Now.Millisecond);
+            
             int n = list.Count;  
             while(n > 1)
             {  


### PR DESCRIPTION
System.Random() initialisation is obviously based on a low resolution timestamp of the current time, which yields identical shuffles if called in close succession.

![shuffle_problem](https://cloud.githubusercontent.com/assets/11939428/8567676/9dbb702c-2567-11e5-8f7a-7f7b01cff392.png)

Solution: Use milliseconds, which provide more variation.
